### PR TITLE
Add comprehensive Events API with CRUD operations

### DIFF
--- a/src/models/__init__.py
+++ b/src/models/__init__.py
@@ -1,4 +1,4 @@
-from .event import Event
+from .event import Event, EventPriceTier
 from .user import User, UserAccount
 
-__all__ = ["Event", "User", "UserAccount"]
+__all__ = ["Event", "EventPriceTier", "User", "UserAccount"]

--- a/src/models/event.py
+++ b/src/models/event.py
@@ -1,12 +1,50 @@
-from sqlalchemy import Column, Integer, String
+from datetime import date, time
+from decimal import Decimal
+
+from sqlalchemy import Boolean, Date, ForeignKey, Integer, Numeric, String, Text, Time
+from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from core.database import Base
 
 
 class Event(Base):
+    """
+    Represents a golf event/tournament.
+    This is the anchor table for the event management system.
+    """
+
     __tablename__ = "event"
     __table_args__ = {"schema": "saga"}
 
-    id = Column(Integer, primary_key=True, index=True)
-    township = Column(String, nullable=False)
-    golf_course = Column(String, nullable=False)
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True)
+    date: Mapped[date] = mapped_column(Date, nullable=False)
+    township: Mapped[str] = mapped_column(String(100), nullable=False)
+    state: Mapped[str] = mapped_column(String(50), nullable=False)
+    zipcode: Mapped[int] = mapped_column(Integer, nullable=False)
+    golf_course: Mapped[str] = mapped_column(String(200), nullable=False)
+    start_time: Mapped[time | None] = mapped_column(Time, nullable=True)
+
+    # Relationships
+    price_tiers: Mapped[list["EventPriceTier"]] = relationship(
+        "EventPriceTier", back_populates="event", cascade="all, delete-orphan"
+    )
+
+
+class EventPriceTier(Base):
+    """
+    Represents pricing options for an event (e.g. "Early Bird", "Member", "Guest").
+    Tiers can be activated/deactivated without deletion for historical integrity.
+    """
+
+    __tablename__ = "event_price_tier"
+    __table_args__ = {"schema": "saga"}
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True)
+    event_id: Mapped[int] = mapped_column(Integer, ForeignKey("saga.event.id"), nullable=False)
+    tier_name: Mapped[str] = mapped_column(String(100), nullable=False)
+    price: Mapped[Decimal] = mapped_column(Numeric(10, 2), nullable=False)
+    description: Mapped[str | None] = mapped_column(Text, nullable=True)
+    is_active: Mapped[bool] = mapped_column(Boolean, default=True, nullable=False)
+
+    # Relationships
+    event: Mapped["Event"] = relationship("Event", back_populates="price_tiers")

--- a/src/repositories/__init__.py
+++ b/src/repositories/__init__.py
@@ -1,4 +1,4 @@
 from .auth_repository import AuthRepository
-from .event_repository import get_events
+from .event_repository import EventRepository, PriceTierRepository
 
-__all__ = ["AuthRepository", "get_events"]
+__all__ = ["AuthRepository", "EventRepository", "PriceTierRepository"]

--- a/src/repositories/event_repository.py
+++ b/src/repositories/event_repository.py
@@ -1,7 +1,94 @@
-from sqlalchemy.orm import Session
+from datetime import date
 
-from models.event import Event
+from sqlalchemy import select
+from sqlalchemy.orm import Session, joinedload
+
+from models.event import Event, EventPriceTier
 
 
-def get_events(db: Session):
-    return db.query(Event).all()
+class EventRepository:
+    def __init__(self, db: Session):
+        self.db = db
+
+    def get_all(
+        self,
+        skip: int = 0,
+        limit: int = 100,
+        upcoming_only: bool = False,
+    ) -> list[Event]:
+        stmt = select(Event)
+        if upcoming_only:
+            stmt = stmt.where(Event.date >= date.today())
+        stmt = stmt.order_by(Event.date).offset(skip).limit(limit)
+        return list(self.db.execute(stmt).scalars().all())
+
+    def count(self, upcoming_only: bool = False) -> int:
+        stmt = select(Event)
+        if upcoming_only:
+            stmt = stmt.where(Event.date >= date.today())
+        return len(list(self.db.execute(stmt).scalars().all()))
+
+    def get_by_id(self, event_id: int) -> Event | None:
+        stmt = select(Event).where(Event.id == event_id)
+        return self.db.execute(stmt).scalar_one_or_none()
+
+    def get_by_id_with_tiers(self, event_id: int) -> Event | None:
+        stmt = select(Event).options(joinedload(Event.price_tiers)).where(Event.id == event_id)
+        return self.db.execute(stmt).unique().scalar_one_or_none()
+
+    def create(self, event: Event) -> Event:
+        self.db.add(event)
+        self.db.flush()
+        return event
+
+    def update(self, event: Event, updates: dict) -> Event:
+        for key, value in updates.items():
+            if value is not None:
+                setattr(event, key, value)
+        self.db.flush()
+        return event
+
+    def delete(self, event: Event) -> None:
+        self.db.delete(event)
+
+    def commit(self) -> None:
+        self.db.commit()
+
+    def rollback(self) -> None:
+        self.db.rollback()
+
+
+class PriceTierRepository:
+    def __init__(self, db: Session):
+        self.db = db
+
+    def get_by_event_id(self, event_id: int, active_only: bool = False) -> list[EventPriceTier]:
+        stmt = select(EventPriceTier).where(EventPriceTier.event_id == event_id)
+        if active_only:
+            stmt = stmt.where(EventPriceTier.is_active.is_(True))
+        return list(self.db.execute(stmt).scalars().all())
+
+    def get_by_id(self, tier_id: int) -> EventPriceTier | None:
+        stmt = select(EventPriceTier).where(EventPriceTier.id == tier_id)
+        return self.db.execute(stmt).scalar_one_or_none()
+
+    def create(self, tier: EventPriceTier) -> EventPriceTier:
+        self.db.add(tier)
+        self.db.flush()
+        return tier
+
+    def update(self, tier: EventPriceTier, updates: dict) -> EventPriceTier:
+        for key, value in updates.items():
+            if value is not None:
+                setattr(tier, key, value)
+        self.db.flush()
+        return tier
+
+    def delete(self, tier: EventPriceTier) -> None:
+        self.db.delete(tier)
+
+    def commit(self) -> None:
+        self.db.commit()
+
+    def rollback(self) -> None:
+        self.db.rollback()

--- a/src/routers/events.py
+++ b/src/routers/events.py
@@ -1,13 +1,141 @@
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, Query, status
 from sqlalchemy.orm import Session
 
 from core.database import get_db
-from schemas.event import EventRead
-from services.event_service import list_events
+from schemas.event import (
+    EventCreate,
+    EventList,
+    EventRead,
+    EventReadWithTiers,
+    EventUpdate,
+    PriceTierCreate,
+    PriceTierRead,
+    PriceTierUpdate,
+)
+from services.event_service import EventService
 
 router = APIRouter(prefix="/api/events", tags=["Events"])
 
 
-@router.get("/", response_model=list[EventRead])
-def get_events(db: Session = Depends(get_db)):
-    return list_events(db)
+# ============ Event Endpoints ============
+
+
+@router.get("/", response_model=EventList)
+def list_events(
+    skip: int = Query(0, ge=0),
+    limit: int = Query(100, ge=1, le=100),
+    upcoming_only: bool = Query(False, description="Only return events on or after today"),
+    db: Session = Depends(get_db),
+) -> EventList:
+    """
+    List all events with pagination.
+
+    - **skip**: Number of events to skip (for pagination)
+    - **limit**: Maximum number of events to return (max 100)
+    - **upcoming_only**: If true, only return future events
+    """
+    service = EventService(db)
+    events, total = service.list_events(skip=skip, limit=limit, upcoming_only=upcoming_only)
+    return EventList(events=events, total=total)
+
+
+@router.get("/{event_id}", response_model=EventReadWithTiers)
+def get_event(event_id: int, db: Session = Depends(get_db)) -> EventReadWithTiers:
+    """
+    Get a single event by ID, including its price tiers.
+    """
+    service = EventService(db)
+    return service.get_event_with_tiers(event_id)
+
+
+@router.post("/", response_model=EventReadWithTiers, status_code=status.HTTP_201_CREATED)
+def create_event(data: EventCreate, db: Session = Depends(get_db)) -> EventReadWithTiers:
+    """
+    Create a new event.
+
+    Optionally include price tiers in the request body to create them
+    along with the event.
+    """
+    service = EventService(db)
+    return service.create_event(data)
+
+
+@router.put("/{event_id}", response_model=EventRead)
+def update_event(
+    event_id: int,
+    data: EventUpdate,
+    db: Session = Depends(get_db),
+) -> EventRead:
+    """
+    Update an existing event.
+
+    Only the fields provided will be updated.
+    """
+    service = EventService(db)
+    return service.update_event(event_id, data)
+
+
+@router.delete("/{event_id}", status_code=status.HTTP_204_NO_CONTENT)
+def delete_event(event_id: int, db: Session = Depends(get_db)) -> None:
+    """
+    Delete an event and all its associated price tiers.
+    """
+    service = EventService(db)
+    service.delete_event(event_id)
+
+
+# ============ Price Tier Endpoints ============
+
+
+@router.get("/{event_id}/price-tiers", response_model=list[PriceTierRead])
+def get_event_price_tiers(
+    event_id: int,
+    active_only: bool = Query(False, description="Only return active price tiers"),
+    db: Session = Depends(get_db),
+) -> list[PriceTierRead]:
+    """
+    Get all price tiers for an event.
+    """
+    service = EventService(db)
+    return service.get_event_price_tiers(event_id, active_only=active_only)
+
+
+@router.post(
+    "/{event_id}/price-tiers",
+    response_model=PriceTierRead,
+    status_code=status.HTTP_201_CREATED,
+)
+def create_price_tier(
+    event_id: int,
+    data: PriceTierCreate,
+    db: Session = Depends(get_db),
+) -> PriceTierRead:
+    """
+    Create a new price tier for an event.
+    """
+    service = EventService(db)
+    return service.create_price_tier(event_id, data)
+
+
+@router.put("/price-tiers/{tier_id}", response_model=PriceTierRead)
+def update_price_tier(
+    tier_id: int,
+    data: PriceTierUpdate,
+    db: Session = Depends(get_db),
+) -> PriceTierRead:
+    """
+    Update an existing price tier.
+
+    Only the fields provided will be updated.
+    """
+    service = EventService(db)
+    return service.update_price_tier(tier_id, data)
+
+
+@router.delete("/price-tiers/{tier_id}", status_code=status.HTTP_204_NO_CONTENT)
+def delete_price_tier(tier_id: int, db: Session = Depends(get_db)) -> None:
+    """
+    Delete a price tier.
+    """
+    service = EventService(db)
+    service.delete_price_tier(tier_id)

--- a/src/schemas/__init__.py
+++ b/src/schemas/__init__.py
@@ -7,15 +7,31 @@ from .auth import (
     TokenResponse,
     UserResponse,
 )
-from .event import EventRead
+from .event import (
+    EventCreate,
+    EventList,
+    EventRead,
+    EventReadWithTiers,
+    EventUpdate,
+    PriceTierCreate,
+    PriceTierRead,
+    PriceTierUpdate,
+)
 
 __all__ = [
+    "EventCreate",
+    "EventList",
+    "EventRead",
+    "EventReadWithTiers",
+    "EventUpdate",
     "LoginRequest",
     "LoginResponse",
+    "PriceTierCreate",
+    "PriceTierRead",
+    "PriceTierUpdate",
     "SignUpRequest",
     "SignUpResponse",
     "TokenPayload",
     "TokenResponse",
     "UserResponse",
-    "EventRead",
 ]

--- a/src/schemas/event.py
+++ b/src/schemas/event.py
@@ -1,10 +1,71 @@
-from pydantic import BaseModel
+import datetime
+from decimal import Decimal
+
+from pydantic import BaseModel, Field
+
+# ============ Price Tier Schemas ============
 
 
-class EventRead(BaseModel):
+class PriceTierBase(BaseModel):
+    tier_name: str = Field(..., min_length=1, max_length=100)
+    price: Decimal = Field(..., ge=0)
+    description: str | None = None
+    is_active: bool = True
+
+
+class PriceTierCreate(PriceTierBase):
+    pass
+
+
+class PriceTierUpdate(BaseModel):
+    tier_name: str | None = Field(None, min_length=1, max_length=100)
+    price: Decimal | None = Field(None, ge=0)
+    description: str | None = None
+    is_active: bool | None = None
+
+
+class PriceTierRead(PriceTierBase):
     id: int
-    township: str
-    golf_course: str
+    event_id: int
 
-    class Config:
-        from_attributes = True  # Pydantic v2 (ORM mode)
+    model_config = {"from_attributes": True}
+
+
+# ============ Event Schemas ============
+
+
+class EventBase(BaseModel):
+    date: datetime.date
+    township: str = Field(..., min_length=1, max_length=100)
+    state: str = Field(..., min_length=2, max_length=50)
+    zipcode: int = Field(..., ge=10000, le=99999)
+    golf_course: str = Field(..., min_length=1, max_length=200)
+    start_time: datetime.time | None = None
+
+
+class EventCreate(EventBase):
+    price_tiers: list[PriceTierCreate] | None = None
+
+
+class EventUpdate(BaseModel):
+    date: datetime.date | None = None
+    township: str | None = Field(None, min_length=1, max_length=100)
+    state: str | None = Field(None, min_length=2, max_length=50)
+    zipcode: int | None = Field(None, ge=10000, le=99999)
+    golf_course: str | None = Field(None, min_length=1, max_length=200)
+    start_time: datetime.time | None = None
+
+
+class EventRead(EventBase):
+    id: int
+
+    model_config = {"from_attributes": True}
+
+
+class EventReadWithTiers(EventRead):
+    price_tiers: list[PriceTierRead] = []
+
+
+class EventList(BaseModel):
+    events: list[EventRead]
+    total: int

--- a/src/services/__init__.py
+++ b/src/services/__init__.py
@@ -1,4 +1,4 @@
 from .auth_service import AuthService, create_access_token, decode_access_token
-from .event_service import list_events
+from .event_service import EventService
 
-__all__ = ["AuthService", "create_access_token", "decode_access_token", "list_events"]
+__all__ = ["AuthService", "EventService", "create_access_token", "decode_access_token"]

--- a/src/services/event_service.py
+++ b/src/services/event_service.py
@@ -1,7 +1,162 @@
+from fastapi import HTTPException, status
 from sqlalchemy.orm import Session
 
-from repositories.event_repository import get_events
+from models.event import Event, EventPriceTier
+from repositories.event_repository import EventRepository, PriceTierRepository
+from schemas.event import EventCreate, EventUpdate, PriceTierCreate, PriceTierUpdate
 
 
-def list_events(db: Session):
-    return get_events(db)
+class EventService:
+    def __init__(self, db: Session):
+        self.event_repo = EventRepository(db)
+        self.tier_repo = PriceTierRepository(db)
+
+    def list_events(
+        self,
+        skip: int = 0,
+        limit: int = 100,
+        upcoming_only: bool = False,
+    ) -> tuple[list[Event], int]:
+        events = self.event_repo.get_all(skip=skip, limit=limit, upcoming_only=upcoming_only)
+        total = self.event_repo.count(upcoming_only=upcoming_only)
+        return events, total
+
+    def get_event(self, event_id: int) -> Event:
+        event = self.event_repo.get_by_id(event_id)
+        if not event:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=f"Event with id {event_id} not found",
+            )
+        return event
+
+    def get_event_with_tiers(self, event_id: int) -> Event:
+        event = self.event_repo.get_by_id_with_tiers(event_id)
+        if not event:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=f"Event with id {event_id} not found",
+            )
+        return event
+
+    def create_event(self, data: EventCreate) -> Event:
+        try:
+            event = Event(
+                date=data.date,
+                township=data.township,
+                state=data.state,
+                zipcode=data.zipcode,
+                golf_course=data.golf_course,
+                start_time=data.start_time,
+            )
+            self.event_repo.create(event)
+
+            if data.price_tiers:
+                for tier_data in data.price_tiers:
+                    tier = EventPriceTier(
+                        event_id=event.id,
+                        tier_name=tier_data.tier_name,
+                        price=tier_data.price,
+                        description=tier_data.description,
+                        is_active=tier_data.is_active,
+                    )
+                    self.tier_repo.create(tier)
+
+            self.event_repo.commit()
+            return self.event_repo.get_by_id_with_tiers(event.id)
+        except Exception as e:
+            self.event_repo.rollback()
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail=f"Failed to create event: {e!s}",
+            ) from e
+
+    def update_event(self, event_id: int, data: EventUpdate) -> Event:
+        event = self.get_event(event_id)
+        try:
+            updates = data.model_dump(exclude_unset=True)
+            self.event_repo.update(event, updates)
+            self.event_repo.commit()
+            return event
+        except Exception as e:
+            self.event_repo.rollback()
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail=f"Failed to update event: {e!s}",
+            ) from e
+
+    def delete_event(self, event_id: int) -> None:
+        event = self.get_event(event_id)
+        try:
+            self.event_repo.delete(event)
+            self.event_repo.commit()
+        except Exception as e:
+            self.event_repo.rollback()
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail=f"Failed to delete event: {e!s}",
+            ) from e
+
+    # ============ Price Tier Methods ============
+
+    def get_event_price_tiers(
+        self, event_id: int, active_only: bool = False
+    ) -> list[EventPriceTier]:
+        self.get_event(event_id)
+        return self.tier_repo.get_by_event_id(event_id, active_only=active_only)
+
+    def create_price_tier(self, event_id: int, data: PriceTierCreate) -> EventPriceTier:
+        self.get_event(event_id)
+        try:
+            tier = EventPriceTier(
+                event_id=event_id,
+                tier_name=data.tier_name,
+                price=data.price,
+                description=data.description,
+                is_active=data.is_active,
+            )
+            self.tier_repo.create(tier)
+            self.tier_repo.commit()
+            return tier
+        except Exception as e:
+            self.tier_repo.rollback()
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail=f"Failed to create price tier: {e!s}",
+            ) from e
+
+    def update_price_tier(self, tier_id: int, data: PriceTierUpdate) -> EventPriceTier:
+        tier = self.tier_repo.get_by_id(tier_id)
+        if not tier:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=f"Price tier with id {tier_id} not found",
+            )
+        try:
+            updates = data.model_dump(exclude_unset=True)
+            self.tier_repo.update(tier, updates)
+            self.tier_repo.commit()
+            return tier
+        except Exception as e:
+            self.tier_repo.rollback()
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail=f"Failed to update price tier: {e!s}",
+            ) from e
+
+    def delete_price_tier(self, tier_id: int) -> None:
+        tier = self.tier_repo.get_by_id(tier_id)
+        if not tier:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=f"Price tier with id {tier_id} not found",
+            )
+        try:
+            self.tier_repo.delete(tier)
+            self.tier_repo.commit()
+        except Exception as e:
+            self.tier_repo.rollback()
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail=f"Failed to delete price tier: {e!s}",
+            ) from e


### PR DESCRIPTION
## Summary
- Add full Event model matching database schema (date, township, state, zipcode, golf_course, start_time)
- Add EventPriceTier model for flexible event pricing
- Implement EventRepository and PriceTierRepository with SQLAlchemy
- Implement EventService with business logic for all operations
- Add complete REST API for events and price tiers

## API Endpoints

| Method | Endpoint | Description |
|--------|----------|-------------|
| GET | `/api/events/` | List events with pagination and filtering |
| GET | `/api/events/{id}` | Get event details with price tiers |
| POST | `/api/events/` | Create event (optionally with price tiers) |
| PUT | `/api/events/{id}` | Update event |
| DELETE | `/api/events/{id}` | Delete event and associated tiers |
| GET | `/api/events/{id}/price-tiers` | List price tiers for event |
| POST | `/api/events/{id}/price-tiers` | Add price tier to event |
| PUT | `/api/events/price-tiers/{id}` | Update price tier |
| DELETE | `/api/events/price-tiers/{id}` | Delete price tier |

## Test plan
- [x] List events returns empty array when no events exist
- [x] Create event with price tiers succeeds
- [x] Get event by ID returns event with price tiers
- [x] Update event modifies only specified fields
- [x] Get price tiers returns all tiers for event
- [x] All code passes ruff linting

## Dependencies
This PR depends on #7 (auth refactor) being merged first.

🤖 Generated with [Claude Code](https://claude.ai/code)